### PR TITLE
Consistent upper/lower-case (letter A)

### DIFF
--- a/Glosario.md
+++ b/Glosario.md
@@ -1,8 +1,8 @@
 | Inglés                                | Castellano                                                                   | Catalán                                                                |
 |---------------------------------------|------------------------------------------------------------------------------|------------------------------------------------------------------------|
-| A/B testing                           | Pruebas A/B / Realización de Pruebas A/B                                     | Proves A/B / Realització de Proves A/B                                 |
-| Abuse(r) Story                        | Historia de Abuso / Caso de Abuso                                            | Història d'Abús                                                        |
-| Acceptance Tests                      | Pruebas de Aceptación                                                        | Proves d'Aceptació                                                     |
+| A/B testing                           | Pruebas A/B / Realización de pruebas A/B                                     | Proves A/B / Realització de proves A/B                                 |
+| Abuse(r) Story                        | Historia de abuso / Caso de abuso                                            | Història d'abús                                                        |
+| Acceptance Tests                      | Pruebas de aceptación                                                        | Proves d'acceptació                                                     |
 | Affinity                              | Afinidad                                                                     | Afinitat                                                               |
 | Affinity estimation                   | Estimación por afinidad                                                      | Estimació per afinitat                                                 |
 | Agile                                 | Ágil                                                                         | Àgil                                                                   |
@@ -12,9 +12,9 @@
 | Anomaly detection techniques          | Técnicas de detección de anomalías                                           | Tècniques de detecció d'anomalies                                      |
 | Anti-pattern                          | Anti-patrón                                                                  | Anti-patró                                                             |
 | Antifragility                         | Antifragilidad                                                               | Antifragilitat                                                         |
-| Application Deployment                | Despliegue de Aplicaciones                                                   | Desplegament d'aplicacions                                             |
-| Artifact Management                   | Gestión de Artefactos                                                        | Gestió d'artefactes                                                     |
-| Artifact repository                   | Repositorio de artefactos                                                    | Repositori d'artefactes                                              |
+| Application Deployment                | Despliegue de aplicaciones                                                   | Desplegament d'aplicacions                                             |
+| Artifact Management                   | Gestión de artefactos                                                        | Gestió d'artefactes                                                     |
+| Artifact Repository                   | Repositorio de artefactos                                                    | Repositori d'artefactes                                              |
 | Automated provisioning                | Aprovisionamiento automatizado                                               | Aprovisionament automatitzat                                          |
 | Automated testing                     | Pruebas automatizadas / Testeo automatizado / Testing automatizado           | Proves automatitzades / Testeig automatitzat / Testing automatitzat    |
 | Automated tests                       | Pruebas automatizadas                                                        | Proves automatitzades                                                  |


### PR DESCRIPTION
Made consistent the use of upper/lower-case in EN/ES/CA (until now only for items starting with letter A).

Please take into account that the use of upper-case, which is extended and usually correct in English, is usually not correct in Spanish/Catalan.

Note. To be applied also to the new item Application Development.