### PR TITLE
Spanish/Catalan translation of Bad path

### DIFF
--- a/Glosario.md
+++ b/Glosario.md
@@ -21,7 +21,7 @@
 | Automated tests                       | Pruebas automatizadas                                                        | Proves automatitzades                                                  |
 | Automation                            | Automatización                                                               | Automatització                                                         |
 | Backlog                               | Backlog / Lista de tareas                                                    | Backlog / Llista de tasques                                            |
-| Bad path                              | Camino Erróneo / Prueba Errónea                                              | Camí Erroni / Prova Erronea                                            |
+| Bad path                              | Camino erróneo / Prueba errónea                                              | Camí erroni / Prova errònia                                            |
 | Binary file                           | Fichero binario                                                              | Fitxer binari                                                          |
 | Blameless                             | Libre de culpa / sin culpa                                                   | Lliure de culpa / sense culpa                                          |
 | Blameless post mortem                 | Blameless post mortem                                                        | Blameless post mortem                                                  |


### PR DESCRIPTION
Corrected typo in Catalan translation of Bad path.
Made consistent the use of upper/lower-case in ES and CA.